### PR TITLE
Fix the spacing for the command to be rendered correctly

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,11 +28,11 @@ end
 # and if it's omitted then the agent will need to be approved
 # in the Threat Stack UI
 
-cmd = "cloudsight setup --deploy-key=#{node['threatstack']['deploy_key']} "
-cmd += "--hostname='#{node['threatstack']['hostname']}'" if node['threatstack']['hostname']
+cmd = "cloudsight setup --deploy-key=#{node['threatstack']['deploy_key']}"
+cmd += " --hostname='#{node['threatstack']['hostname']}'" if node['threatstack']['hostname']
 
 node['threatstack']['rulesets'].each do |r|
-  cmd += "--ruleset='#{r}' "
+  cmd += " --ruleset='#{r}'"
 end
 
 execute 'cloudsight setup' do

--- a/spec/default_multi_ruleset_spec.rb
+++ b/spec/default_multi_ruleset_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'threatstack::default' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      node.set['threatstack']['deploy_key'] = "ABCD1234"
+      node.set['threatstack']['rulesets'] = ['base', 'ubuntu', 'cassandra']
+    end.converge(described_recipe)
+  end
+
+  it 'executes the cloudsight setup with list of rulesets' do
+    expect(chef_run).to run_execute('cloudsight setup').with(
+      command: "cloudsight setup --deploy-key=ABCD1234 --ruleset='base' --ruleset='ubuntu' --ruleset='cassandra'"
+    )
+  end
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -17,7 +17,7 @@ describe 'threatstack::default' do
 
   it 'executes the cloudsight setup' do
     expect(chef_run).to run_execute('cloudsight setup').with(
-      command: "cloudsight setup --deploy-key=ABCD1234 --ruleset='Base Rule Set' "
+      command: "cloudsight setup --deploy-key=ABCD1234 --ruleset='Base Rule Set'"
     )
   end
 end

--- a/spec/default_with_hostname_spec.rb
+++ b/spec/default_with_hostname_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'threatstack::default' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      node.set['threatstack']['deploy_key'] = "ABCD1234"
+      node.set['threatstack']['hostname'] = "test_server-i-abc123"
+    end.converge(described_recipe)
+  end
+
+  it 'executes the cloudsight setup with a configured hostname' do
+    expect(chef_run).to run_execute('cloudsight setup').with(
+      command: "cloudsight setup --deploy-key=ABCD1234 --hostname='test_server-i-abc123' --ruleset='Base Rule Set'"
+    )
+  end
+end


### PR DESCRIPTION
This fixes #2 
Also add tests for when using a hostname as well as when setting multiple rulesets for a host.