### PR TITLE
Add encrypted databag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Usage
 2. Add your deploy api key. The recommended way is to use an encrypted databag
 with name and item specified by the corresponding attributes. The cookbook will
 use the `'deploy_key'` value from the databag by default.
-
 You can also set the key directly or using a wrapper cookbook in the `node['threatstack']['deploy_key']` attribute.
 Setting the key will disable the encrypted data bag lookup.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ Usage
   cookbook 'threatstack', '~> 1.0.0'
   ```
 
-2. Add your deploy api key to the `node['threatstack']['deploy_key']` attribute at a higher precedence level. Using either a wrapper cookbook or role or databag
+2. Add your deploy api key. The recommended way is to use an encrypted databag
+with name and item specified by the corresponding attributes. The cookbook will
+use the `'deploy_key'` value from the databag by default.
+
+You can also set the key directly or using a wrapper cookbook in the `node['threatstack']['deploy_key']` attribute.
+Setting the key will disable the encrypted data bag lookup.
 
 3. Add this recipe to your runlist or include in another recipe
 
@@ -61,8 +66,16 @@ Attributes
 
 `node['threatstack']['pkg_action']` - Set to `:upgrade` if you want to take the latest release (defaults to `:install`)
 
-`node['threatstack']['deploy_key']` - Override this with your deploy key for agent registration
+`node['threatstack']['deploy_key']` - Override this with your deploy key for agent registration.
+
+`node['threatstack']['data_bag_name']` - Name of the encrypted databag containing Threat Stack secrets.
+
+`node['threatstack']['data_bag_item']` - Name of the encrypted databag item containing Threat Stack secrets.
 
 `node['threatstack']['rulesets']` - Set or override this with an array of rulesets to apply to the node
 
-`node['threatstack']['hostname']` - register the agent in the UI by a specific name (defaults to hostname)
+`node['threatstack']['hostname']` - register the agent in the UI by a specific name (defaults to hostname)i
+
+Encrypted Data Bag Contents
+===========================
+`deploy_key` - the deploy key for agent registration.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,12 @@
 
 default['threatstack']['version'] = nil
 default['threatstack']['pkg_action'] = :install
-default['threatstack']['deploy_key'] = nil
 default['threatstack']['rulesets'] = ['Base Rule Set']
 default['threatstack']['hostname'] = nil
 default['threatstack']['ignore_failure'] = true
+
+# You can set the deploy key directly, or use the encrypted databag
+# parameters below. The value searched for will be 'deploy_key'
+default['threatstack']['deploy_key'] = nil
+default['threatstack']['data_bag_name'] = 'threatstack'
+default['threatstack']['data_bag_item'] = 'api_keys'

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -6,7 +6,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'debian',
         version: '7.8'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -29,7 +31,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'ubuntu',
         version: '10.04'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -48,7 +52,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'ubuntu',
         version: '12.04'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -67,7 +73,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'ubuntu',
         version: '14.04'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -86,7 +94,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'redhat',
         version: '6.5'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -104,7 +114,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'centos',
         version: '6.5'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 
@@ -122,7 +134,9 @@ describe 'threatstack::default' do
       runner = ChefSpec::SoloRunner.new(
         platform: 'amazon',
         version: '2012.09'
-      )
+      ) do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+      end
       runner.converge(described_recipe)
     end
 


### PR DESCRIPTION
Previously encrypted databags as a way to store the deploy key were only referenced in the README. This PR adds built in support for retrieving a deploy_key from encrypted databag while still allowing to explicitly specify the deploy_key. Data bag name and item are configurable to account for environment
variations, as per best practice.