### PR TITLE
Reconfigure ThreatStack agent automatically if rulesets for the node change

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,9 @@
 
 default['threatstack']['version'] = nil
 default['threatstack']['pkg_action'] = :install
-default['threatstack']['rulesets'] = ['Base Rule Set']
+# If no rulesets are specified the agent will register to the default
+# rule set, according to a comment in recipes/default.rb
+default['threatstack']['rulesets'] = []
 default['threatstack']['hostname'] = nil
 default['threatstack']['ignore_failure'] = true
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -3,12 +3,28 @@ require 'spec_helper'
 describe 'threatstack::default' do
   context 'single-ruleset-test' do
     let(:chef_run) do
-      ChefSpec::SoloRunner.new.converge(described_recipe)
+      ChefSpec::SoloRunner.new do |node|
+        node.set['threatstack']['rulesets'] = ['Base Rule Set']
+      end.converge(described_recipe)
     end
 
     before do
       contents = { 'deploy_key' => 'ABCD1234' }
       allow(Chef::EncryptedDataBagItem).to receive(:load).with('threatstack', 'api_keys').and_return(contents)
+    end
+
+    it 'creates a ruleset file' do
+      expect(chef_run).to render_file('/opt/threatstack/etc/active_rulesets.txt').with_content("Base Rule Set\n")
+    end
+
+    it 'does not touch the flag file' do
+      resource = chef_run.file('/opt/threatstack/cloudsight/config/.secret')
+      expect(resource).to do_nothing
+    end
+
+    it 'does not stop threatstack services' do
+      resource = chef_run.execute('stop threatstack services')
+      expect(resource).to do_nothing
     end
 
     it 'executes the cloudsight setup' do
@@ -22,6 +38,7 @@ describe 'threatstack::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.set['threatstack']['deploy_key'] = 'EFGH5678'
+        node.set['threatstack']['rulesets'] = ['Base Rule Set']
       end.converge(described_recipe)
     end
 
@@ -40,10 +57,44 @@ describe 'threatstack::default' do
       end.converge(described_recipe)
     end
 
+    it 'stores all rulesets into a file' do
+      expect(chef_run).to render_file('/opt/threatstack/etc/active_rulesets.txt').with_content("base\nubuntu\ncassandra\n")
+    end
+
     it 'executes the cloudsight setup with multiple rulesets' do
       expect(chef_run).to run_execute('cloudsight setup').with(
         command: "cloudsight setup --deploy-key=ABCD1234 --ruleset='base' --ruleset='ubuntu' --ruleset='cassandra'"
       )
+    end
+  end
+
+  context 'ruleset-configuration-changes' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+        node.set['threatstack']['rulesets'] = %w(base enhanced)
+      end.converge(described_recipe)
+    end
+
+    before(:each) do
+      allow(File).to receive(:exists?).with(anything).and_call_original
+      allow(File).to receive(:exists?).with('/opt/threatstack/etc/active_rulesets.txt').and_return true
+      allow(File).to receive(:read).with(anything).and_call_original
+      allow(File).to receive(:read).with('/opt/threatstack/etc/active_rulesets.txt').and_return "base\n"
+    end
+
+    it 'deletes the flag file' do
+      resource = chef_run.file('/opt/threatstack/etc/active_rulesets.txt')
+      expect(resource).to notify('file[/opt/threatstack/cloudsight/config/.secret]').to(:delete).immediately
+    end
+
+    it 'stops threatstack' do
+      resource = chef_run.file('/opt/threatstack/etc/active_rulesets.txt')
+      expect(resource).to notify('execute[stop threatstack services]').to(:run).immediately
+    end
+
+    it 're-runs cloudsight setup' do
+      expect(chef_run).to run_execute('cloudsight setup')
     end
   end
 
@@ -57,7 +108,7 @@ describe 'threatstack::default' do
 
     it 'executes the cloudsight setup with a configured hostname' do
       expect(chef_run).to run_execute('cloudsight setup').with(
-        command: "cloudsight setup --deploy-key=ABCD1234 --hostname='test_server-i-abc123' --ruleset='Base Rule Set'"
+        command: "cloudsight setup --deploy-key=ABCD1234 --hostname='test_server-i-abc123'"
       )
     end
   end


### PR DESCRIPTION
According to TS support, there is no easy way to obtain a list of configured rulesets
for a node. Add a file to store the list and reconfigure the agent when the list changes.
As part of reconfiguration ThreatStack agent needs to be stopped. The reconfiguration
will cause a stale TS node with the same name to show in the UI for a while.