### PR TITLE
Uninstall should not run TS registration or drop files

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 include_recipe "threatstack::#{node['platform_family']}" if node['threatstack']['repo_enable']
 
 package 'threatstack-agent' do
@@ -44,7 +43,9 @@ node['threatstack']['rulesets'].each do |r|
   cmd += " --ruleset='#{r}'"
 end
 
-unless [:remove, :purge].include? node['threatstack']['pkg_action']
+# If the attributes are specified using YAML, there appears to be no way
+# to get back to symbols. The package resource has no problem with that.
+unless [:remove, :purge, 'remove', 'purge'].include? node['threatstack']['pkg_action']
   # This file is maintained because the list of rulesets is not readily accessible
   # in a ThreatStack agent install, and we want to re-run the registration
   # process when the ruleset list changes.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,40 +44,42 @@ node['threatstack']['rulesets'].each do |r|
   cmd += " --ruleset='#{r}'"
 end
 
-# This file is maintained because the list of rulesets is not readily accessible
-# in a ThreatStack agent install, and we want to re-run the registration
-# process when the ruleset list changes.
-file '/opt/threatstack/etc/active_rulesets.txt' do
-  content node['threatstack']['rulesets'].join("\n").concat("\n")
-  mode 0644
-  owner 'root'
-  group 'root'
-end
-
-# deleting this file allows cloudsight to be reconfigured after installation
-file '/opt/threatstack/cloudsight/config/.secret' do
-  action :nothing
-  subscribes :delete, 'file[/opt/threatstack/etc/active_rulesets.txt]', :immediately
-end
-
-# Only if we are about to reconfigure a running instance
-execute 'stop threatstack services' do
-  command '/usr/bin/cloudsight stop'
-  action :nothing
-  subscribes :run, 'file[/opt/threatstack/etc/active_rulesets.txt]', :immediately
-end
-
-execute 'cloudsight setup' do
-  command cmd
-  action :run
-  retries 3
-  timeout 60
-  ignore_failure node['threatstack']['ignore_failure']
-  if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('11.14.0')
-    sensitive true
+unless [:remove, :purge].include? node['threatstack']['pkg_action']
+  # This file is maintained because the list of rulesets is not readily accessible
+  # in a ThreatStack agent install, and we want to re-run the registration
+  # process when the ruleset list changes.
+  file '/opt/threatstack/etc/active_rulesets.txt' do
+    content node['threatstack']['rulesets'].join("\n").concat("\n")
+    mode 0644
+    owner 'root'
+    group 'root'
   end
-  not_if do
-    ::File.exist?('/opt/threatstack/cloudsight/config/.audit') &&
-      ::File.exist?('/opt/threatstack/cloudsight/config/.secret')
+
+  # deleting this file allows cloudsight to be reconfigured after installation
+  file '/opt/threatstack/cloudsight/config/.secret' do
+    action :nothing
+    subscribes :delete, 'file[/opt/threatstack/etc/active_rulesets.txt]', :immediately
+  end
+
+  # Only if we are about to reconfigure a running instance
+  execute 'stop threatstack services' do
+    command '/usr/bin/cloudsight stop'
+    action :nothing
+    subscribes :run, 'file[/opt/threatstack/etc/active_rulesets.txt]', :immediately
+  end
+
+  execute 'cloudsight setup' do
+    command cmd
+    action :run
+    retries 3
+    timeout 60
+    ignore_failure node['threatstack']['ignore_failure']
+    if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('11.14.0')
+      sensitive true
+    end
+    not_if do
+      ::File.exist?('/opt/threatstack/cloudsight/config/.audit') &&
+        ::File.exist?('/opt/threatstack/cloudsight/config/.secret')
+    end
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -142,4 +142,26 @@ describe 'threatstack::default' do
       expect(chef_run).to install_package('threatstack-agent')
     end
   end
+
+  context 'uninstall-test' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['threatstack']['pkg_action'] = :remove
+      end.converge(described_recipe)
+    end
+
+    before do
+      contents = { 'deploy_key' => 'ABCD1234' }
+      allow(Chef::EncryptedDataBagItem).to receive(:load).with('threatstack', 'api_keys').and_return(contents)
+    end
+
+    it 'uninstalls the package' do
+      expect(chef_run).to remove_package('threatstack-agent')
+    end
+
+    it 'does not run unnecessary actions' do
+      expect(chef_run).to_not create_file('/opt/threatstack/etc/active_rulesets.txt')
+      expect(chef_run).to_not run_execute('cloudsight setup')
+    end
+  end
 end


### PR DESCRIPTION
Many of the operations in the recipe are only used when installing. Make sure no unnecessary operations are performed when the recipe is used to remove ThreatStack.

(in particular, the list-of-rulesets file should not be created, and TS registration should not be run since by that point TS is no longer present on the node)
