### PR TITLE
Fix error when node['threatstack']['agent_config_args'] is passed in as an array.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -150,8 +150,7 @@ if node['threatstack']['configure_agent']
     # We can only set one argument at a time to build a string of `cloudsight
     # config` commands per argument.
     cloudsight_config_cmds = []
-    unless node['threatstack']['agent_config_args'].nil?
-      agent_config_args = node['threatstack']['agent_config_args'].split(' ')
+    unless agent_config_args.empty?
       agent_config_args.each do |arg|
         cloudsight_config_cmds.push("cloudsight config #{arg}")
       end


### PR DESCRIPTION
Recently added ability to pass in an array instead of space delimited string for node['threatstack']['agent_config_args'].  Fixes a spot where the new style was not supported.