### PR TITLE
Update metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,8 +5,8 @@ license          'Apache 2.0'
 description      'Installs/Configures Threat Stack cloudsight components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.7.3'
-issues_url       'https://github.com/threatstack/threatstack-chef/issues'
-source_url       'https://github.com/threatstack/threatstack-chef'
+issues_url       'https://github.com/threatstack/threatstack-chef/issues' if respond_to?(:issues_url)
+source_url       'https://github.com/threatstack/threatstack-chef' if respond_to?(:source_url)
 
 supports 'amazon'
 supports 'centos'
@@ -15,3 +15,5 @@ supports 'ubuntu'
 
 depends  'apt'
 depends  'yum'
+
+chef_version '>= 11.0' if respond_to?(:chef_version)


### PR DESCRIPTION
* Add `respond_to?` conditional for issues/source urls
* Add minimum chef version

---

I wasn't sure based on https://github.com/threatstack/threatstack-chef/commit/d204965ea2a6bf903a02e0699c7a5b2a9b197899 if the minimum supported Chef version is meant to be 11 or 12.

If version 11 is supported, the `respond_to?` may be needed to prevent metadata parsing errors since the issues/source urls were introduced in version 12.
If version 12 is supported, `chef_version '>= 12.0'` would be helpful.