### PR TITLE
Allow deferring agent start to the end of a Chef run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Attributes
 
 `node['threatstack']['agent_config_args']` - array of arguments to enable platform features via `cloudsight config`.
 
+`node['threatstack']['cloudsight_service_timer']` - a [Chef timer](https://docs.chef.io/resource_common.html#resource-common-notifications) to manage the agent service with.
+
 Encrypted Data Bag Contents
 ===========================
 `deploy_key` - the deploy key for agent registration.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,3 +48,7 @@ default['threatstack']['agent_config_args'] = []
 
 # if configure_agent=false then we remove start in the cookbook
 default['threatstack']['cloudsight_service_action'] = [:enable, :start]
+
+# Determines whether to start/restart the agent during or at the end of a
+# converge. Should be a valid Chef timer.
+default['threatstack']['cloudsight_service_timer'] = 'immediately'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -224,7 +224,7 @@ if node['threatstack']['configure_agent']
           no_changes
         end
       end
-      notifies :restart, 'service[cloudsight]'
+      notifies :restart, 'service[cloudsight]', node['threatstack']['cloudsight_service_timer']
     end
   end
 end
@@ -235,8 +235,19 @@ end
 if node['threatstack']['configure_agent'] == false
   node['threatstack']['cloudsight_service_action'].delete('start')
 end
+ruby_block 'manage cloudsight service' do
+  block {}
+  if node['threatstack']['cloudsight_service_action'].respond_to?(:each)
+    node['threatstack']['cloudsight_service_action'].each do |action|
+      notifies action, 'service[cloudsight]', node['threatstack']['cloudsight_service_timer']
+    end
+  else
+    notifies node['threatstack']['cloudsight_service_action'], 'service[cloudsight]',
+             node['threatstack']['cloudsight_service_timer']
+  end
+end
 service 'cloudsight' do
-  action node['threatstack']['cloudsight_service_action']
+  action :nothing
   supports restart: true
   stop_command 'service cloudsight stop; exit 0' # Because init script exits 3...
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -139,7 +139,7 @@ describe 'threatstack::default' do
     end
 
     it 'enables the threatstack-agent service' do
-      expect(chef_run).to enable_service('cloudsight')
+      expect(chef_run.ruby_block('manage cloudsight service')).to notify('service[cloudsight]').to(:enable).immediately
     end
   end
 


### PR DESCRIPTION
This change allows specifying a Chef timer for management of the Threatstack agent service.

During a node's initial converge, unless Threatstack is the very last recipe on the node's run list, the agent will capture a significant amount of noise from Chef's provisioning steps. While the default behavior, `immediately`, mimics the cookbook's current behavior, this will allow setting `delayed` to defer agent startup to the end of the Chef run.