### PR TITLE
Update cookbook to support only chef > 12.15

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - metadata.rb
     - Rakefile
     - vendor/**/*
+    - spec/**/*
     - Gemfile
 
 Style/ConditionalAssignment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 - gem --version
 env:
 - CHEF_VERSION="= 12.15.19"
-- CHEF_VERSION="= 12.21.3"
+- CHEF_VERSION="= 12.21.1"
 - CHEF_VERSION=">= 0.0.0"   # installs latest
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_install:
 - gem update --system 2.6.6
 - gem --version
 env:
-- CHEF_VERSION="= 12.5.1"
-- CHEF_VERSION="= 12.9.41"
+- CHEF_VERSION="= 12.15.19"
+- CHEF_VERSION="= 12.21.3"
 - CHEF_VERSION=">= 0.0.0"   # installs latest
 
 notifications:

--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,3 @@
 source 'https://supermarket.getchef.com'
 
-cookbook 'apt'
-cookbook 'yum'
-
 metadata

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,15 +1,7 @@
 DEPENDENCIES
-  apt
   threatstack
     path: .
     metadata: true
-  yum
 
 GRAPH
-  apt (4.0.2)
-    compat_resource (>= 12.10)
-  compat_resource (12.14.7)
-  threatstack (1.7.2)
-    apt (>= 0.0.0)
-    yum (>= 0.0.0)
-  yum (4.0.0)
+  threatstack (2.0.0)

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'berkshelf', '= 5.6.5'
 gem 'rubocop', '= 0.49.1'
 gem 'foodcritic', '= 11.2.0'
 gem 'serverspec', '= 2.37.1'
-gem 'stove', '= 4.1.1'
+gem 'stove', '= 5.2.0'
 gem 'test-kitchen'
 
 if chefversion = ENV['CHEF_VERSION']

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'chefspec', '= 5.2.0'
-gem 'berkshelf', '= 4.1.1'
-gem 'rubocop', '= 0.43.0'
-gem 'foodcritic', '= 8.0.0'
+gem 'chefspec', '= 6.2.0'
+gem 'berkshelf', '= 5.6.5'
+gem 'rubocop', '= 0.49.1'
+gem 'foodcritic', '= 11.2.0'
 gem 'serverspec', '= 2.37.1'
 gem 'stove', '= 4.1.1'
 gem 'test-kitchen'

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Chef recipes to deploy the Threat Stack server agent
 
 Requirements
 ============
-- chef > 11.0
+- chef > 12.15
 
 Platforms
 ---------

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ use the `'deploy_key'` value from the databag by default.
 You can also set the key directly or using a wrapper cookbook in the `node['threatstack']['deploy_key']` attribute.
 Setting the key will disable the encrypted data bag lookup.
 
+Additionally you we can read the deploy key from the `node.run_state['threatstack']['deploy_key']` location
+Simply set the value of the deploy key in the run state at that location.
+
 3. Add this recipe to your runlist or include in another recipe
 
 Attributes

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Setting the key will disable the encrypted data bag lookup.
 Additionally you we can read the deploy key from the `node.run_state['threatstack']['deploy_key']` location
 Simply set the value of the deploy key in the run state at that location.
 
-3. Add this recipe to your runlist or include in another recipe
+3. Set the `node['threatstack']['feature_plan']` appropriately for your organzation
+
+4. Add this recipe to your runlist or include in another recipe
 
 Attributes
 ==========

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,7 +47,7 @@ default['threatstack']['agent_extra_args'] = ''
 default['threatstack']['agent_config_args'] = []
 
 # if configure_agent=false then we remove start in the cookbook
-default['threatstack']['cloudsight_service_action'] = [:enable, :start]
+default['threatstack']['cloudsight_service_action'] = %i(enable start)
 
 # Determines whether to start/restart the agent during or at the end of a
 # converge. Should be a valid Chef timer.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,7 +47,7 @@ default['threatstack']['agent_extra_args'] = ''
 default['threatstack']['agent_config_args'] = []
 
 # if configure_agent=false then we remove start in the cookbook
-default['threatstack']['cloudsight_service_action'] = %i(enable start)
+default['threatstack']['cloudsight_service_action'] = %i[enable start]
 
 # Determines whether to start/restart the agent during or at the end of a
 # converge. Should be a valid Chef timer.

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,17 +1,16 @@
 name             'threatstack'
 maintainer       'Threat Stack'
 maintainer_email 'support@threatstack.com'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'Installs/Configures Threat Stack cloudsight components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.7.3'
-issues_url       'https://github.com/threatstack/threatstack-chef/issues'
-source_url       'https://github.com/threatstack/threatstack-chef'
+version          '2.0.0'
+issues_url       'https://github.com/threatstack/threatstack-chef/issues' if respond_to?(:issues_url)
+source_url       'https://github.com/threatstack/threatstack-chef' if respond_to?(:source_url)
 
 supports 'amazon'
 supports 'centos'
 supports 'redhat'
 supports 'ubuntu'
 
-depends  'apt'
-depends  'yum'
+chef_version '>= 12.15' if respond_to?(:chef_version)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -64,18 +64,8 @@ when 'monitor'
   feature_plan_arg = 'agent_type="m"'
 when 'investigate', 'legacy'
   feature_plan_arg = 'agent_type="i"'
-when nil
-  feature_plan_arg = 'agent_type="i"'
-  log 'Set feature_plan' do
-    level :warn
-    message 'The feature_plan attribute must be set. This will become a hard failure at a later date.'
-  end
 else
-  log 'Set feature_plan' do
-    level :warn
-    message 'The feature_plan attribute must be set. This will become a hard failure at a later date.'
-  end
-  raise
+  raise "The node['threatstack']['feature_plan'] attribute must be set."
 end
 
 # make sure we don't have [, 'foo=bar'] which breaks us later.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,7 +65,7 @@ when 'monitor'
 when 'investigate', 'legacy'
   feature_plan_arg = 'agent_type="i"'
 else
-  raise "The node['threatstack']['feature_plan'] attribute must be set."
+  raise "The node['threatstack']['feature_plan'] attribute must be set to one of (monitor, investigate, or legacy)."
 end
 
 # make sure we don't have [, 'foo=bar'] which breaks us later.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -109,7 +109,7 @@ if node.run_state.key?('threatstack')
 elsif node['threatstack']['deploy_key']
   deploy_key = node['threatstack']['deploy_key']
 else
-  deploy_key = Chef::EncryptedDataBagItem.load(
+  deploy_key = data_bag_item(
     node['threatstack']['data_bag_name'],
     node['threatstack']['data_bag_item']
   )['deploy_key']
@@ -171,9 +171,7 @@ if node['threatstack']['configure_agent']
     retries 3
     timeout 60
     ignore_failure node['threatstack']['ignore_failure']
-    if Gem::Version.new(Chef::VERSION) >= Gem::Version.new('11.14.0')
-      sensitive true
-    end
+    sensitive true
     not_if do
       ::File.exist?('/opt/threatstack/cloudsight/config/.audit') &&
         ::File.exist?('/opt/threatstack/cloudsight/config/.secret')

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -5,7 +5,7 @@ describe 'threatstack::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['rulesets'] = ['Base Rule Set']
-        node.normal['threatstack']['feature_plan'] = 'monitor'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end.converge(described_recipe)
     end
 
@@ -40,7 +40,7 @@ describe 'threatstack::default' do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['deploy_key'] = 'EFGH5678'
         node.normal['threatstack']['rulesets'] = ['Base Rule Set']
-        node.normal['threatstack']['feature_plan'] = 'monitor'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end.converge(described_recipe)
     end
 
@@ -56,7 +56,7 @@ describe 'threatstack::default' do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['rulesets'] = %w(base ubuntu cassandra)
-        node.normal['threatstack']['feature_plan'] = 'monitor'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end.converge(described_recipe)
     end
 
@@ -76,7 +76,7 @@ describe 'threatstack::default' do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['rulesets'] = %w(base enhanced)
-        node.normal['threatstack']['feature_plan'] = 'monitor'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end.converge(described_recipe)
     end
 
@@ -107,7 +107,7 @@ describe 'threatstack::default' do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['agent_extra_args'] = '--foo=bar'
-        node.normal['threatstack']['feature_plan'] = 'monitor'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end.converge(described_recipe)
     end
 
@@ -123,7 +123,7 @@ describe 'threatstack::default' do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['hostname'] = 'test_server-i-abc123'
-        node.normal['threatstack']['feature_plan'] = 'monitor'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end.converge(described_recipe)
     end
 
@@ -141,7 +141,7 @@ describe 'threatstack::default' do
         version: '14.04'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
-        node.normal['threatstack']['feature_plan'] = 'monitor'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end.converge(described_recipe)
     end
 
@@ -157,7 +157,7 @@ describe 'threatstack::default' do
         version: '14.04'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
-        node.normal['threatstack']['feature_plan'] = 'monitor'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end.converge(described_recipe)
     end
 
@@ -173,7 +173,7 @@ describe 'threatstack::default' do
         version: '6.6'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
-        node.normal['threatstack']['feature_plan'] = 'monitor'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end.converge(described_recipe)
     end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -4,13 +4,13 @@ describe 'threatstack::default' do
   context 'single-ruleset-test' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['threatstack']['rulesets'] = ['Base Rule Set']
+        node.normal['threatstack']['rulesets'] = ['Base Rule Set']
       end.converge(described_recipe)
     end
 
     before do
       contents = { 'deploy_key' => 'ABCD1234' }
-      allow(Chef::EncryptedDataBagItem).to receive(:load).with('threatstack', 'api_keys').and_return(contents)
+      stub_data_bag_item('threatstack', 'api_keys').and_return(contents)
     end
 
     it 'creates a ruleset file' do
@@ -37,8 +37,8 @@ describe 'threatstack::default' do
   context 'explicit-deploy-key' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['threatstack']['deploy_key'] = 'EFGH5678'
-        node.set['threatstack']['rulesets'] = ['Base Rule Set']
+        node.normal['threatstack']['deploy_key'] = 'EFGH5678'
+        node.normal['threatstack']['rulesets'] = ['Base Rule Set']
       end.converge(described_recipe)
     end
 
@@ -52,8 +52,8 @@ describe 'threatstack::default' do
   context 'multi-ruleset-test' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
-        node.set['threatstack']['rulesets'] = %w(base ubuntu cassandra)
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['rulesets'] = %w(base ubuntu cassandra)
       end.converge(described_recipe)
     end
 
@@ -71,8 +71,8 @@ describe 'threatstack::default' do
   context 'ruleset-configuration-changes' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
-        node.set['threatstack']['rulesets'] = %w(base enhanced)
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['rulesets'] = %w(base enhanced)
       end.converge(described_recipe)
     end
 
@@ -101,8 +101,8 @@ describe 'threatstack::default' do
   context 'agent-extra-args' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
-        node.set['threatstack']['agent_extra_args'] = '--foo=bar'
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['agent_extra_args'] = '--foo=bar'
       end.converge(described_recipe)
     end
 
@@ -116,8 +116,8 @@ describe 'threatstack::default' do
   context 'hostname-test' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
-        node.set['threatstack']['hostname'] = 'test_server-i-abc123'
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['hostname'] = 'test_server-i-abc123'
       end.converge(described_recipe)
     end
 
@@ -134,7 +134,7 @@ describe 'threatstack::default' do
         platform: 'ubuntu',
         version: '14.04'
       ) do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end.converge(described_recipe)
     end
 
@@ -149,7 +149,7 @@ describe 'threatstack::default' do
         platform: 'ubuntu',
         version: '14.04'
       ) do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end.converge(described_recipe)
     end
 
@@ -164,7 +164,7 @@ describe 'threatstack::default' do
         platform: 'redhat',
         version: '6.6'
       ) do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end.converge(described_recipe)
     end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -5,6 +5,7 @@ describe 'threatstack::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['rulesets'] = ['Base Rule Set']
+        node.normal['threatstack']['feature_plan'] = 'monitor'
       end.converge(described_recipe)
     end
 
@@ -39,6 +40,7 @@ describe 'threatstack::default' do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['deploy_key'] = 'EFGH5678'
         node.normal['threatstack']['rulesets'] = ['Base Rule Set']
+        node.normal['threatstack']['feature_plan'] = 'monitor'
       end.converge(described_recipe)
     end
 
@@ -54,6 +56,7 @@ describe 'threatstack::default' do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['rulesets'] = %w(base ubuntu cassandra)
+        node.normal['threatstack']['feature_plan'] = 'monitor'
       end.converge(described_recipe)
     end
 
@@ -73,6 +76,7 @@ describe 'threatstack::default' do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['rulesets'] = %w(base enhanced)
+        node.normal['threatstack']['feature_plan'] = 'monitor'
       end.converge(described_recipe)
     end
 
@@ -103,6 +107,7 @@ describe 'threatstack::default' do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['agent_extra_args'] = '--foo=bar'
+        node.normal['threatstack']['feature_plan'] = 'monitor'
       end.converge(described_recipe)
     end
 
@@ -118,6 +123,7 @@ describe 'threatstack::default' do
       ChefSpec::SoloRunner.new do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['hostname'] = 'test_server-i-abc123'
+        node.normal['threatstack']['feature_plan'] = 'monitor'
       end.converge(described_recipe)
     end
 
@@ -135,6 +141,7 @@ describe 'threatstack::default' do
         version: '14.04'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'monitor'
       end.converge(described_recipe)
     end
 
@@ -150,6 +157,7 @@ describe 'threatstack::default' do
         version: '14.04'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'monitor'
       end.converge(described_recipe)
     end
 
@@ -165,6 +173,7 @@ describe 'threatstack::default' do
         version: '6.6'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'monitor'
       end.converge(described_recipe)
     end
 

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -7,7 +7,7 @@ describe 'threatstack::default' do
         platform: 'debian',
         version: '7.8'
       ) do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
     end
@@ -26,34 +26,13 @@ describe 'threatstack::default' do
     end
   end
 
-  context 'ubuntu-lucid' do
-    let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new(
-        platform: 'ubuntu',
-        version: '10.04'
-      ) do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
-      end
-      runner.converge(described_recipe)
-    end
-
-    it 'sets up the apt repository' do
-      expect(chef_run).to add_apt_repository('threatstack').with(
-        uri: 'https://pkg.threatstack.com/Ubuntu',
-        distribution: 'lucid',
-        components: ['main'],
-        key: 'https://app.threatstack.com/APT-GPG-KEY-THREATSTACK'
-      )
-    end
-  end
-
   context 'ubuntu-precise' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'ubuntu',
         version: '12.04'
       ) do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
     end
@@ -74,7 +53,7 @@ describe 'threatstack::default' do
         platform: 'ubuntu',
         version: '14.04'
       ) do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
     end
@@ -89,13 +68,34 @@ describe 'threatstack::default' do
     end
   end
 
+  context 'ubuntu-xenial' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '16.04'
+      ) do |node|
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+      end
+      runner.converge(described_recipe)
+    end
+
+    it 'sets up the apt repository' do
+      expect(chef_run).to add_apt_repository('threatstack').with(
+        uri: 'https://pkg.threatstack.com/Ubuntu',
+        distribution: 'xenial',
+        components: ['main'],
+        key: 'https://app.threatstack.com/APT-GPG-KEY-THREATSTACK'
+      )
+    end
+  end
+
   context 'redhat' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'redhat',
         version: '6.5'
       ) do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
     end
@@ -119,7 +119,7 @@ describe 'threatstack::default' do
         platform: 'centos',
         version: '6.5'
       ) do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
     end
@@ -143,7 +143,7 @@ describe 'threatstack::default' do
         platform: 'amazon',
         version: '2012.09'
       ) do |node|
-        node.set['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
     end

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -8,6 +8,7 @@ describe 'threatstack::default' do
         version: '7.8'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end
       runner.converge(described_recipe)
     end
@@ -33,6 +34,7 @@ describe 'threatstack::default' do
         version: '12.04'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end
       runner.converge(described_recipe)
     end
@@ -54,6 +56,7 @@ describe 'threatstack::default' do
         version: '14.04'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end
       runner.converge(described_recipe)
     end
@@ -75,6 +78,7 @@ describe 'threatstack::default' do
         version: '16.04'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end
       runner.converge(described_recipe)
     end
@@ -96,6 +100,7 @@ describe 'threatstack::default' do
         version: '6.5'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end
       runner.converge(described_recipe)
     end
@@ -120,6 +125,7 @@ describe 'threatstack::default' do
         version: '6.5'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end
       runner.converge(described_recipe)
     end
@@ -144,6 +150,7 @@ describe 'threatstack::default' do
         version: '2012.09'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
       end
       runner.converge(described_recipe)
     end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,4 +1,5 @@
 # Encoding: utf-8
+
 require 'serverspec'
 
 set :backend, :exec


### PR DESCRIPTION
Testing for less than chef 12.15 is getting more challenging due to the test frameworks not easily supporting testing both 11x and 13x.  We are going to be dropping support for chef < 12.15 in the 2.0 release of this cookbook.  As such this PR removes any 11.x specifics and updates the tests to ensure coverage.