### PR TITLE
Fix issue on Chef 11+ with configure_agent disabled

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -237,7 +237,7 @@ end
 # resource because the workflow differs between fresh installation and
 # upgrades.  The package scripts will handle this.
 if node['threatstack']['configure_agent'] == false
-  node['threatstack']['cloudsight_service_action'].delete('start')
+  node.default['threatstack']['cloudsight_service_action'].delete('start')
 end
 ruby_block 'manage cloudsight service' do
   block {}


### PR DESCRIPTION
When setting `configure_agent` to false the following error was seen:

```
Chef::Exceptions::ImmutableAttributeModification
------------------------------------------------
Node attributes are read-only when you do not specify which precedence level to set. To set an attribute use code like `node.default["key"] = "value"'

Cookbook Trace:
---------------
  /home/ubuntu/chef-solo/cookbooks/threatstack/recipes/default.rb:240:in `from_file'
  ....

Relevant File Content:
----------------------
/home/ubuntu/chef-solo/cookbooks/threatstack/recipes/default.rb:

233:    end
234:  end
235:
236:  # NOTE: We do not signal the cloudsight service to restart via the package
237:  # resource because the workflow differs between fresh installation and
238:  # upgrades.  The package scripts will handle this.
239:  if node['threatstack']['configure_agent'] == false
240>>   node['threatstack']['cloudsight_service_action'].delete('start')
241:  end
242:  ruby_block 'manage cloudsight service' do
243:    block {}
244:    if node['threatstack']['cloudsight_service_action'].respond_to?(:each)
245:      node['threatstack']['cloudsight_service_action'].each do |action|
246:        notifies action, 'service[cloudsight]', node['threatstack']['cloudsight_service_timer']
247:      end
248:    else
249:      notifies node['threatstack']['cloudsight_service_action'], 'service[cloudsight]',

System Info:
------------
chef_version=13.6.0
platform=ubuntu
platform_version=16.04
ruby=ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-linux]
program_name=chef-solo worker: ppid=14206;start=19:39:03;
executable=/opt/chef/bin/chef-solo
```

Precendence must be set when setting the attribute, see:

https://blog.chef.io/2013/02/05/chef-11-in-depth-attributes-changes/