### PR TITLE
Fix use of run_state deploy_key attribute with fallback to node or data_bag attributes

### DIFF
--- a/libraries/recipe_helpers.rb
+++ b/libraries/recipe_helpers.rb
@@ -1,0 +1,51 @@
+# Cookbook Name:: threatstack
+# Library:: recipe_helpers
+
+# module ThreatstackHelper contains threatstack recipe helpers
+module ThreatstackHelper
+  # top level method called by the recipe to find the deploy_key
+  def get_deploy_key(node)
+    find_my_attribute(node, 'deploy_key')
+  end
+
+  # Generate the cloudsight command string(s) required to configure the agent
+  def gen_cmd(node, agent_config_args_full)
+    cmd = ''
+    deploy_key = get_deploy_key(node)
+    unless agent_config_args_full.empty?
+      agent_config_args_full.each do |arg|
+        cmd += "cloudsight config #{arg} ;"
+      end
+    end
+    cmd += "cloudsight setup --deploy-key=#{deploy_key}"
+    cmd += " --hostname='#{node['threatstack']['hostname']}'" if node['threatstack']['hostname']
+    cmd += " #{node['threatstack']['agent_extra_args']}" if node['threatstack']['agent_extra_args'] != ''
+    unless node['threatstack']['rulesets'].empty?
+      node['threatstack']['rulesets'].each do |r|
+        cmd += " --ruleset='#{r}'"
+      end
+    end
+    cmd
+  end
+
+  private
+
+  # Resuable find attribute method where run_state, normal attributes, and data_bags are looked through to find the value.
+  def find_my_attribute(node, attribute)
+    if node.run_state.key?('threatstack') && node.run_state['threatstack'].key?(attribute)
+      node.run_state['threatstack'][attribute]
+    elsif node['threatstack'].key?(attribute) && node['threatstack'][attribute]
+      node['threatstack'][attribute]
+    else
+      begin
+        data_bag_item(node['threatstack']['data_bag_name'], node['threatstack']['data_bag_item'])[attribute]
+      rescue
+        nil
+      end
+    end
+  end
+end
+
+Chef::Recipe.send(:include, ThreatstackHelper)
+Chef::Resource.send(:include, ThreatstackHelper)
+Chef::Provider.send(:include, ThreatstackHelper)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -100,14 +100,6 @@ else
   agent_version = '0.0.0'
 end
 
-# Find and set the deploy_key using the recipe helper
-ruby_block 'threatstack-deploy-key-unset' do
-  block do
-    raise "Set ['threatstack']['deploy_key'] as an attribute, a data bag item, or on the node's run_state."
-  end
-  only_if { get_deploy_key(node).nil? }
-end
-
 # Register the Threat Stack agent - Rulesets are not required
 # and if it's omitted then the agent will be placed into a
 # default rule set (most like 'Base Rule Set')
@@ -141,6 +133,14 @@ unless node['threatstack']['rulesets'].empty?
 end
 
 if node['threatstack']['configure_agent']
+  # Find and set the deploy_key using the recipe helper
+  ruby_block 'threatstack-deploy-key-unset' do
+    block do
+      raise "Set ['threatstack']['deploy_key'] as an attribute, a data bag item, or on the node's run_state."
+    end
+    only_if { get_deploy_key(node).nil? }
+  end
+  
   # `cloudsight setup` resource runs `cloudsight config` if there is stuff to
   # configure.
   execute 'cloudsight setup' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -51,6 +51,23 @@ describe 'threatstack::default' do
     end
   end
 
+  context 'explicit-run_state-deploy-key' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.run_state['threatstack'] = {}
+        node.run_state['threatstack']['deploy_key'] = 'IJKL9012'
+        node.normal['threatstack']['rulesets'] = ['Base Rule Set']
+        node.normal['threatstack']['feature_plan'] = 'investigate'
+      end.converge(described_recipe)
+    end
+
+    it 'prefers the explicit deploy_key when one is specified' do
+      expect(chef_run).to run_execute('cloudsight setup').with(
+        command: "cloudsight config agent_type=\"i\" ;cloudsight setup --deploy-key=IJKL9012 --ruleset='Base Rule Set'"
+      )
+    end
+  end
+
   context 'multi-ruleset-test' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|


### PR DESCRIPTION
Fails some Rubocop tests due to AbcSize and MethodLength errors.  I can not figure out the AmbiguousBlockAssociation failure, there's no other way to define lazy on an attribute in Chef that I'm aware of.  I didn't want to exclude these tests, I'll leave that up to the maintainers.  Only fails 1 cookstyle test in attributes/default.rb which wasn't touched by this.

I did not change the run_state attribute being used, it is still node.run_state['threatstack']['deploy_key'].  This does require a 2 step process when creating or testing this attribute, but I considered this out of scope for the update.  

Once a previous or wrapping cookbook gets the attribute set, the recipe will correctly check for its existence during the converge phase.  You can not check for run_state attributes during the compile phase.  Using data_bags or the normal attribute still works, they were moved to the helper library.