### PR TITLE
Added ability to manage cloudsight with systemd instead of the SysVinit system

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,3 +55,7 @@ default['threatstack']['cloudsight_service_action'] = %i[enable start]
 # Determines whether to start/restart the agent during or at the end of a
 # converge. Should be a valid Chef timer.
 default['threatstack']['cloudsight_service_timer'] = 'immediately'
+
+# By default, the Threat Stack service is managed through init scripts.
+# Use this option to have systemd manage the service instead
+default['threatstack']['use_systemd'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -263,27 +263,24 @@ if node['threatstack']['use_systemd']
   # Create, enable, and start the systemd unit file
   systemd_unit 'cloudsight.service' do
     content(
-      {
-        Unit: {
-          Description: 'Threat Stack Cloudsight Service',
-          After: 'network.target',
-        },
-        Service: {
-          Type: 'forking',
-          PIDFile: '/opt/threatstack/cloudsight/pids/cloudsight.pid',
-          ExecStart: '/opt/threatstack/bin/cloudsight start',
-          ExecReload: '/opt/threatstack/bin/cloudsight restart',
-          ExecStop: '/opt/threatstack/bin/cloudsight stop',
-          TimeoutSec: '30',
-          Restart: 'always',
-        },
-        Install: {
-          WantedBy: 'multi-user.target'
-        }
-      }
-    )
-    action [:create, :enable, :start]
-  end  
+      Unit: {
+        Description: 'Threat Stack Cloudsight Service',
+        After: 'network.target'
+      },
+      Service: {
+        Type: 'forking',
+        PIDFile: '/opt/threatstack/cloudsight/pids/cloudsight.pid',
+        ExecStart: '/opt/threatstack/bin/cloudsight start',
+        ExecReload: '/opt/threatstack/bin/cloudsight restart',
+        ExecStop: '/opt/threatstack/bin/cloudsight stop',
+        TimeoutSec: '30',
+        Restart: 'always'
+      },
+      Install: {
+        WantedBy: 'multi-user.target'
+      })
+    action %i[create enable start]
+  end
 end
 
 # NOTE: We do not signal the cloudsight service to restart via the package

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -278,7 +278,8 @@ if node['threatstack']['use_systemd']
       },
       Install: {
         WantedBy: 'multi-user.target'
-      })
+      }
+    )
     action %i[create enable start]
   end
 end


### PR DESCRIPTION
@petecheslock Made some modifications for systemd. If the attribute "default['threatstack']['use_systemd']" is set to true (false by default), then after cloudsight configuration and setup is complete:
- The agent will be stopped
- Init scripts will be removed
- A systemd unit file will be created for cloudsight
- The cloudsight service will be started using systemd