### PR TITLE
Don't special-case debian repo to wheezy

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,7 +9,10 @@ provisioner:
 platforms:
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: ubuntu-18.04
   - name: debian-7.8
+  - name: debian-8
+  - name: debian-9
   - name: centos-6.7
   - name: centos-7.3
   - name: fedora-25

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -3,11 +3,7 @@ default['threatstack']['repo']['components'] = ['main']
 
 case node['platform_family']
 when 'debian'
-  if node['platform'] == 'debian'
-    default['threatstack']['repo']['dist'] = 'wheezy'
-  else
-    default['threatstack']['repo']['dist'] = node['lsb']['codename']
-  end
+  default['threatstack']['repo']['dist'] = node['lsb']['codename']
   default['threatstack']['repo']['url'] = 'https://pkg.threatstack.com/Ubuntu'
   default['threatstack']['repo']['key'] = 'https://app.threatstack.com/APT-GPG-KEY-THREATSTACK'
 when 'rhel', 'fedora', 'amazon'

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -24,6 +24,51 @@ describe 'threatstack::default' do
     end
   end
 
+  context 'debian-jessie' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(
+        platform: 'debian',
+        version: '8'
+      ) do |node|
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
+      end
+      runner.converge(described_recipe)
+    end
+
+    it 'installs the apt-transport-http package' do
+      expect(chef_run).to install_package('apt-transport-https')
+    end
+
+    it 'sets up the apt repository' do
+      expect(chef_run).to add_apt_repository('threatstack').with(
+        distribution: 'jessie'
+      )
+    end
+  end
+
+  context 'debian-stretch' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(
+        platform: 'debian',
+        version: '9'
+      ) do |node|
+        node.normal['threatstack']['deploy_key'] = 'ABCD1234'
+        node.normal['threatstack']['feature_plan'] = 'investigate'
+      end
+      runner.converge(described_recipe)
+    end
+
+    it 'installs the apt-transport-http package' do
+      expect(chef_run).to install_package('apt-transport-https')
+    end
+
+    it 'sets up the apt repository' do
+      expect(chef_run).to add_apt_repository('threatstack').with(
+        distribution: 'stretch'
+      )
+    end
+  end
   context 'ubuntu-trusty' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(


### PR DESCRIPTION
The current package fails to install on Stretch because of a package
dependency versioning issue:

```
 threatstack-agent : Depends: base-files (< 8.0) but 9.9+deb9u5 is to be installed
 STDERR: E: Unable to correct problems, you have held broken packages.
 ---- End output of ["apt-get", "-q", "-y", "install",
 "threatstack-agent=1.9.0.0debian7.0"] ----
 Ran ["apt-get", "-q", "-y", "install", "threatstack-agent=1.9.0.0debian7.0"] returned 100
```

The issue is that we're pulling in a version of the agent built for
Wheezy, and this functions as intended when just set to stretch:
```
chef (13.11.3)> node['lsb']['codename']
 => "stretch"
```

While there may have been a reason to fold all debian releases to wheezy
in the past, there's a valid repo for stretch, so this special case can
just be removed.

I was unable to get the serverspec things to run because of ruby issues,
but kitchen passes on the affected distros:

```
Instance             Driver   Provisioner  Verifier  Transport  Last Action    Last Error
default-debian-78    Vagrant  ChefSolo     Busser    Ssh        Verified       <None>
default-debian-8     Vagrant  ChefSolo     Busser    Ssh        Verified       <None>
default-debian-9     Vagrant  ChefSolo     Busser    Ssh        Verified       <None>
```