### PR TITLE
Perform a few more checks to see if the agent needs registering

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,41 @@
+#
+# Cookbook Name:: threatstack
+# Library:: helper
+#
+# Copyright 2014-2021, Threat Stack
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def ts_down?
+  require 'open3'
+  stdout, stderr, status = Open3.capture3('/usr/bin/tsagent status')
+  return stdout.include?('DOWN')
+end
+
+def stale_agent?
+  require 'open3'
+  require 'yaml'
+  require 'date'
+  stdout, stderr, status = Open3.capture3('/usr/bin/tsagent info')
+  stdout.gsub!("\t", '  ')
+  tsagent_info = YAML.load(stdout)
+
+  # If it's never been registered, it's stale.
+  return true if tsagent_info['LastBackendConnection'] == 'N/A'
+
+  # It could be stale if it last connected >24h ago. Would need to get ts_down? to know for sure.
+  return true if (DateTime.now.to_time - tsagent_info['LastBackendConnection'])/3600 > 24.0
+
+  # Otherwise, it's definitely fresh.
+  false
+end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,7 +19,7 @@
 def ts_down?
   require 'open3'
   stdout, stderr, status = Open3.capture3('/usr/bin/tsagent status')
-  return stdout.include?('DOWN')
+  return !stdout.include?('UP Threat Stack Backend Connection')
 end
 
 def stale_agent?

--- a/recipes/agent_setup.rb
+++ b/recipes/agent_setup.rb
@@ -62,9 +62,7 @@ execute 'tsagent setup' do
   timeout 60
   ignore_failure node['threatstack']['ignore_failure']
   sensitive true
-  not_if do
-    ::File.exist?('/opt/threatstack/etc/tsagentd.cfg')
-  end
+  only_if { ts_down? && stale_agent? }
   # default to delayed start in case config is needed.
   notifies :start, 'service[threatstack]'
 end


### PR DESCRIPTION
Instead of checking for /opt/threatstack/etc/tsagentd.cfg, we could use information from `tsagent info` and `tsagent status` to assess whether the agent needs to be registered.

A newly installed agent shows:
```
cable@blah:~$ sudo tsagent status
DOWN Threat Stack Agent Daemon
cable@blah:~$ sudo tsagent info
LastBackendConnection: N/A
ClientConfig:
	None. You must register your agent via `tsagent setup` to generate a client config
```
This passes both tests: 1) not having the `UP Threat Stack Backend Connection` string, and 2) not having a `LastBackendConnection` time. Neat, register the agent.

A functioning agent would show:
```
cable@blah2:~$ sudo tsagent status
  UP Threat Stack Agent Daemon
  UP Threat Stack Backend Connection
  UP Threat Stack Heartbeat Service
  UP Threat Stack Login Collector
  UP Threat Stack Audit Collection
  UP Threat Stack Log Scan Service
  UP Threat Stack Vulnerability Scanner
  UP Threat Stack File Integrity Monitor
LastBackendConnection: 2021-01-13T21:25:12Z
ClientConfig:
	ID: removed
	Key: removed
	Protocol: ALv2
	Backend: wss://cssensors.threatstack.com
```
This would fail both tests: 1) `UP Threat Stack Backend Connection` exists, and 2) `LastBackendConnection` happened within the last 24 hours. No registration needed.