### PR TITLE
Update Chef Cookbook

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,11 +6,11 @@ AllCops:
     - spec/**/*
     - Gemfile
 
-ConditionalAssignment:
+Style/ConditionalAssignment:
   Enabled: false
-FrozenStringLiteralComment:
+Style/FrozenStringLiteralComment:
   Enabled: false
-LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/BlockNesting:
   Enabled: false

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io'
 
 metadata
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,10 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-gem 'stove', '= 6.1.1'
-
 group :development, :unit_tests , :test do
-  gem 'rake', "13.0.1",         :require => false
-  gem 'chefspec', '= 7.3.4',    :require => false
-  gem 'berkshelf', '= 6.3.1'
-  gem 'rubocop', '= 0.61.1'
-  gem 'foodcritic', '= 15.1.0'
+  gem 'rake', "13.0.3",         :require => false
+  gem 'chefspec', '= 9.2.1',    :require => false
+  gem 'berkshelf', '= 7.2.0'
+  gem 'cookstyle', '= 6.16.10'
 end
 
 group :system_tests do

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :development, :unit_tests , :test do
   gem 'rake', "13.0.3",         :require => false
-  gem 'chefspec', '= 9.2.1',    :require => false
-  gem 'berkshelf', '= 7.2.0'
+  gem 'chefspec', '= 7.3.4',    :require => false
+  gem 'berkshelf', '= 6.3.4'
   gem 'cookstyle', '= 6.16.10'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,16 @@
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
-require 'foodcritic'
+require 'cookstyle'
 
-# Style tests. Rubocop and Foodcritic
+# Style tests. Cookstyle combines foodcritic and rubocop.
 namespace :style do
-  desc 'Run Ruby style checks'
-  RuboCop::RakeTask.new(:ruby)
-
-  desc 'Run Chef style checks'
-  FoodCritic::Rake::LintTask.new(:chef) do |t|
-    t.options = {
-      fail_tags: ['any'],
-      tags: ['~FC022']
-    }
+  RuboCop::RakeTask.new(:cookstyle) do |task|
+    task.options << '--display-cop-names'
   end
 end
 
 desc 'Run all style checks'
-task style: ['style:chef', 'style:ruby']
+task style: ['style:cookstyle']
 
 # Rspec and ChefSpec
 desc "Run ChefSpec examples"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: threatstack
+# Cookbook:: threatstack
 # Attributes:: default
 #
-# Copyright 2014-2020, Threat Stack
+# Copyright:: 2014-2020, Threat Stack
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,41 @@
+#
+# Cookbook Name:: threatstack
+# Library:: helper
+#
+# Copyright 2014-2021, Threat Stack
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def ts_down?
+  require 'open3'
+  stdout, stderr, status = Open3.capture3('/usr/bin/tsagent status')
+  return stdout.include?('DOWN')
+end
+
+def stale_agent?
+  require 'open3'
+  require 'yaml'
+  require 'date'
+  stdout, stderr, status = Open3.capture3('/usr/bin/tsagent info')
+  stdout.gsub!("\t", '  ')
+  tsagent_info = YAML.load(stdout)
+
+  # If it's never been registered, it's stale.
+  return true if tsagent_info['LastBackendConnection'] == 'N/A'
+
+  # It could be stale if it last connected >24h ago. Would need to get ts_down? to know for sure.
+  return true if (DateTime.now.to_time - tsagent_info['LastBackendConnection'])/3600 > 24.0
+
+  # Otherwise, it's definitely fresh.
+  false
+end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -37,8 +37,8 @@ def unregistered_agent?
 
   return true if tsagent_info['LastBackendConnection'] == 'N/A'
 
-  # It could be stale if it last connected >24h ago. Would need to exec tsagent status and search 
-  # for "UP Threat Stack Backend Connection" along with this to know for sure. 
+  # It could be stale if it last connected >24h ago. Would need to exec tsagent status and search
+  # for "UP Threat Stack Backend Connection" along with this to know for sure.
   # return true if (DateTime.now.to_time - tsagent_info['LastBackendConnection']) / 3600 > 24.0
 
   # otherwise, probably fresh.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -18,23 +18,23 @@
 
 def ts_down?
   require 'open3'
-  stdout, stderr, status = Open3.capture3('/usr/bin/tsagent status')
-  return !stdout.include?('UP Threat Stack Backend Connection')
+  stdout, = Open3.capture3('/usr/bin/tsagent status')
+  !stdout.include?('UP Threat Stack Backend Connection')
 end
 
 def stale_agent?
   require 'open3'
   require 'yaml'
   require 'date'
-  stdout, stderr, status = Open3.capture3('/usr/bin/tsagent info')
+  stdout, = Open3.capture3('/usr/bin/tsagent info')
   stdout.gsub!("\t", '  ')
-  tsagent_info = YAML.load(stdout)
+  tsagent_info = YAML.safe_load(stdout)
 
   # If it's never been registered, it's stale.
   return true if tsagent_info['LastBackendConnection'] == 'N/A'
 
   # It could be stale if it last connected >24h ago. Would need to get ts_down? to know for sure.
-  return true if (DateTime.now.to_time - tsagent_info['LastBackendConnection'])/3600 > 24.0
+  return true if (DateTime.now.to_time - tsagent_info['LastBackendConnection']) / 3600 > 24.0
 
   # Otherwise, it's definitely fresh.
   false

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: threatstack
+# Cookbook:: threatstack
 # Library:: helper
 #
-# Copyright 2014-2021, Threat Stack
+# Copyright:: 2014-2021, Threat Stack
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def has_tsagent_info(maj, min, patch)
+def tsagent_info?(maj, min, patch)
   return true if (maj >= 2 && min >= 2) || (maj >= 2 && min >= 1 && patch >= 3)
+
   false
 end
 
@@ -40,7 +41,7 @@ def unregistered_agent?
   # It could be stale if it last connected >24h ago. Would need to get ts_down? to know for sure.
   # This is an option for folks if they leave machines off for 24h or more, but it might be a better
   # function for a wrapper cookbook of some sort.
-  #return true if (DateTime.now.to_time - tsagent_info['LastBackendConnection']) / 3600 > 24.0
+  # return true if (DateTime.now.to_time - tsagent_info['LastBackendConnection']) / 3600 > 24.0
 
   # otherwise, probably fresh.
   false

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,7 +19,7 @@
 def ts_down?
   require 'open3'
   stdout, stderr, status = Open3.capture3('/usr/bin/tsagent status')
-  return stdout.include?('DOWN')
+  return !stdout.include?('UP Threat Stack Backend Connection')
 end
 
 def stale_agent?

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -42,6 +42,6 @@ def unregistered_agent?
   # function for a wrapper cookbook of some sort.
   #return true if (DateTime.now.to_time - tsagent_info['LastBackendConnection']) / 3600 > 24.0
 
-  # Otherwise, it's definitely fresh.
+  # otherwise, probably fresh.
   false
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'support@threatstack.com'
 license          'Apache-2.0'
 description      'Installs/Configures Threat Stack agent components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.4'
+version          '3.0.5'
 issues_url       'https://github.com/threatstack/threatstack-chef/issues' if respond_to?(:issues_url)
 source_url       'https://github.com/threatstack/threatstack-chef' if respond_to?(:source_url)
 

--- a/recipes/agent_setup.rb
+++ b/recipes/agent_setup.rb
@@ -62,9 +62,7 @@ execute 'tsagent setup' do
   timeout 60
   ignore_failure node['threatstack']['ignore_failure']
   sensitive true
-  not_if do
-    ::File.exist?('/opt/threatstack/etc/tsagentd.cfg')
-  end
+  only_if { ts_down? && stale_agent? }
   # default to delayed start in case config is needed.
   notifies :start, 'service[threatstack]'
 end

--- a/recipes/agent_setup.rb
+++ b/recipes/agent_setup.rb
@@ -72,7 +72,7 @@ execute 'tsagent setup' do
   sensitive true
   only_if {
     ts_ver = node['packages']['threatstack-agent']['version'].split('.')
-    has_tsagent_info(ts_ver[0].to_i,ts_ver[1].to_i,ts_ver[2].to_i) ? unregistered_agent? : ::File.exist?('/opt/threatstack/etc/tsagentd.cfg')
+    has_tsagent_info(ts_ver[0].to_i,ts_ver[1].to_i,ts_ver[2].to_i) ? unregistered_agent? : ::File.exist?('/opt/threatstack/etc/agent.db')
   }
   # default to delayed start in case config is needed.
   notifies :start, 'service[threatstack]'

--- a/recipes/agent_setup.rb
+++ b/recipes/agent_setup.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 # We need to get the version of what we installed earlier
-ohai_reload 'Update package list' do
+ohai 'Update package list' do
   plugin 'packages'
 end
 
@@ -72,7 +72,7 @@ execute 'tsagent setup' do
   sensitive true
   only_if {
     ts_ver = node['packages']['threatstack-agent']['version'].split('.')
-    has_tsagent_info(ts_ver[0],ts_ver[1],ts_ver[2]) ? unregistered_agent? : ::File.exist?('/opt/threatstack/etc/tsagentd.cfg')
+    has_tsagent_info(ts_ver[0].to_i,ts_ver[1].to_i,ts_ver[2].to_i) ? unregistered_agent? : ::File.exist?('/opt/threatstack/etc/tsagentd.cfg')
   }
   # default to delayed start in case config is needed.
   notifies :start, 'service[threatstack]'

--- a/recipes/agent_setup.rb
+++ b/recipes/agent_setup.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: threatstack
+# Cookbook:: threatstack
 # Recipe:: default
 #
-# Copyright 2014-2020, Threat Stack
+# Copyright:: 2014-2020, Threat Stack
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,10 +70,10 @@ execute 'tsagent setup' do
   timeout 60
   ignore_failure node['threatstack']['ignore_failure']
   sensitive true
-  only_if {
+  only_if do
     ts_ver = node['packages']['threatstack-agent']['version'].split('.')
-    has_tsagent_info(ts_ver[0].to_i,ts_ver[1].to_i,ts_ver[2].to_i) ? unregistered_agent? : ::File.exist?('/opt/threatstack/etc/agent.db')
-  }
+    tsagent_info?(ts_ver[0].to_i, ts_ver[1].to_i, ts_ver[2].to_i) ? unregistered_agent? : ::File.exist?('/opt/threatstack/etc/agent.db')
+  end
   # default to delayed start in case config is needed.
   notifies :start, 'service[threatstack]'
 end

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: threatstack
+# Cookbook:: threatstack
 # Recipe:: debian
 #
-# Copyright 2014-2020, Threat Stack
+# Copyright:: 2014-2020, Threat Stack
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: threatstack
+# Cookbook:: threatstack
 # Recipe:: default
 #
-# Copyright 2014-2020, Threat Stack
+# Copyright:: 2014-2020, Threat Stack
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ end
 # be a couple exec blocks because we hit a wall with this issue fairly
 # early, but this is a little cleaner.
 service 'auditd' do
-  action %w[stop disable]
+  action %w(stop disable)
   stop_command 'service auditd stop'
 end
 

--- a/recipes/rhel.rb
+++ b/recipes/rhel.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: threatstack
+# Cookbook:: threatstack
 # Recipe:: rhel
 #
-# Copyright 2014-2020, Threat Stack
+# Copyright:: 2014-2020, Threat Stack
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -4,6 +4,7 @@ describe 'threatstack::default' do
   context 'single-ruleset-test' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['rulesets'] = ['Base Rule Set']
       end.converge(described_recipe)
     end
@@ -23,6 +24,7 @@ describe 'threatstack::default' do
   context '1.x version' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '1.9.0'
         node.normal['threatstack']['rulesets'] = ['Base Rule Set']
         node.normal['threatstack']['version'] = '1.9.0ubuntuBlergh'
       end
@@ -42,6 +44,7 @@ describe 'threatstack::default' do
   context '2.x version' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['rulesets'] = ['Base Rule Set']
         node.normal['threatstack']['version'] = '2.blahblah'
       end
@@ -61,6 +64,7 @@ describe 'threatstack::default' do
   context 'explicit-deploy-key' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'EFGH5678'
         node.normal['threatstack']['rulesets'] = ['Base Rule Set']
       end.converge(described_recipe)
@@ -76,6 +80,7 @@ describe 'threatstack::default' do
   context 'multi-ruleset-test' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['rulesets'] = ['Base Rule Set', 'CloudTrail Base Rule Set']
       end.converge(described_recipe)
@@ -91,6 +96,7 @@ describe 'threatstack::default' do
   context 'enable-containers' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['enable_containers'] = true
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end.converge(described_recipe)
@@ -106,6 +112,7 @@ describe 'threatstack::default' do
   context 'dont-enable-containers-when-attr-false' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['enable_containers'] = false
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end.converge(described_recipe)
@@ -121,6 +128,7 @@ describe 'threatstack::default' do
   context 'dont-enable-containers-when-attr-nil' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['enable_containers'] = nil
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end.converge(described_recipe)
@@ -137,6 +145,7 @@ describe 'threatstack::default' do
   context 'agent-extra-args' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['agent_config_args'] = ['foo 1', 'bar 1']
       end.converge(described_recipe)
@@ -163,6 +172,7 @@ describe 'threatstack::default' do
   context 'no agent-extra-args' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end.converge(described_recipe)
     end
@@ -185,6 +195,7 @@ describe 'threatstack::default' do
   context 'install only' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['install_only'] = true
       end.converge(described_recipe)
@@ -212,6 +223,7 @@ describe 'threatstack::default' do
   context 'hostname-test' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['hostname'] = 'test_server-i-abc123'
       end.converge(described_recipe)
@@ -230,6 +242,7 @@ describe 'threatstack::default' do
         platform: 'ubuntu',
         version: '16.04'
       ) do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end.converge(described_recipe)
     end
@@ -245,6 +258,7 @@ describe 'threatstack::default' do
         platform: 'ubuntu',
         version: '18.04'
       ) do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.0.0'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
         node.normal['threatstack']['version'] = '2.0.0.0ubuntu18.56'
       end.converge(described_recipe)
@@ -261,6 +275,7 @@ describe 'threatstack::default' do
         platform: 'redhat',
         version: '7.4'
       ) do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end.converge(described_recipe)
     end

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -6,7 +6,7 @@ describe 'threatstack::default' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'debian',
-        version: '8.10'
+        version: '8.11'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
@@ -28,7 +28,7 @@ describe 'threatstack::default' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'debian',
-        version: '9.3'
+        version: '9.12'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
@@ -91,7 +91,7 @@ describe 'threatstack::default' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'redhat',
-        version: '7.4'
+        version: '7.8'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
@@ -120,7 +120,7 @@ describe 'threatstack::default' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'centos',
-        version: '7.4'
+        version: '7.8.2003'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
@@ -144,7 +144,7 @@ describe 'threatstack::default' do
     let(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'amazon',
-        version: '2017.09'
+        version: '2018.03'
       ) do |node|
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -8,6 +8,7 @@ describe 'threatstack::default' do
         platform: 'debian',
         version: '8.11'
       ) do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
@@ -30,6 +31,7 @@ describe 'threatstack::default' do
         platform: 'debian',
         version: '9.12'
       ) do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
@@ -52,6 +54,7 @@ describe 'threatstack::default' do
         platform: 'ubuntu',
         version: '16.04'
       ) do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
@@ -70,6 +73,7 @@ describe 'threatstack::default' do
         platform: 'ubuntu',
         version: '18.04'
       ) do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
@@ -93,6 +97,7 @@ describe 'threatstack::default' do
         platform: 'redhat',
         version: '7.8'
       ) do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
@@ -122,6 +127,7 @@ describe 'threatstack::default' do
         platform: 'centos',
         version: '7.8.2003'
       ) do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
@@ -146,6 +152,7 @@ describe 'threatstack::default' do
         platform: 'amazon',
         version: '2018.03'
       ) do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)
@@ -170,6 +177,7 @@ describe 'threatstack::default' do
         platform: 'amazon',
         version: '2'
       ) do |node|
+        node.normal['packages']['threatstack-agent']['version'] = '2.3.2'
         node.normal['threatstack']['deploy_key'] = 'ABCD1234'
       end
       runner.converge(described_recipe)

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -116,8 +116,7 @@ describe 'threatstack::default' do
     end
 
     it 'stops and disables auditd' do
-      expect(chef_run).to run_execute('stop_auditd')
-      expect(chef_run).to run_execute('disable_auditd')
+      expect(chef_run).to stop_service('auditd')
     end
   end
 
@@ -195,8 +194,7 @@ describe 'threatstack::default' do
       )
     end
     it 'stops and disables auditd' do
-      expect(chef_run).to run_execute('stop_auditd')
-      expect(chef_run).to run_execute('disable_auditd')
+      expect(chef_run).to stop_service('auditd')
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'chefspec'
 
 RSpec.configure do |config|
   config.platform = 'ubuntu'
-  config.version = '14.04'
+  config.version = '20.04'
 end
 
 ChefSpec::Coverage.start!

--- a/test/cookbooks/install_old_agent/metadata.rb
+++ b/test/cookbooks/install_old_agent/metadata.rb
@@ -1,6 +1,6 @@
 name             'install_old_agent'
 maintainer       'Threat Stack, Inc'
 maintainer_email 'support@threatstack.com'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'A test cookbook to prepare the test environment for: tests'
 version          '0.0.1'

--- a/test/cookbooks/install_old_agent/recipes/default.rb
+++ b/test/cookbooks/install_old_agent/recipes/default.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: install_old_agent
+# Cookbook:: install_old_agent
 # Recipe:: default
 #
-# Copyright 2014-2020, Threat Stack
+# Copyright:: 2014-2020, Threat Stack
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ if node['threatstack']['repo_enable']
   end
 end
 
-execute 'stop_auditd' do # ~FC004 This is a workaround for auditd not stoppable with the standard method
+execute 'stop_auditd' do
   command 'service auditd stop'
   only_if { platform?('amazon') && node['platform_version'] == '2' || platform?('centos', 'redhat') }
 end

--- a/test/cookbooks/setup/metadata.rb
+++ b/test/cookbooks/setup/metadata.rb
@@ -1,7 +1,6 @@
 name             'setup'
 maintainer       'Threat Stack, Inc'
 maintainer_email 'support@threatstack.com'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'A test cookbook to prepare the test environment for: tests'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.0.1'

--- a/test/cookbooks/setup/recipes/default.rb
+++ b/test/cookbooks/setup/recipes/default.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: setup
+# Cookbook:: setup
 # Recipe:: default
 #
-# Copyright 2014-2020, Threat Stack
+# Copyright:: 2014-2020, Threat Stack
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/integration/upgrades/serverspec/default_spec.rb
+++ b/test/integration/upgrades/serverspec/default_spec.rb
@@ -3,7 +3,7 @@ require 'serverspec'
 set :backend, :exec
 
 # Version to expect on install. Change this when we bump versions
-current_version = '2.3.0'
+current_version = '2.3.2'
 
 describe package('threatstack-agent') do
   it { should be_installed }


### PR DESCRIPTION
* Switch from Foodcritic + Rubocop to Cookstyle
* Fix bug where `tsagent setup` looks at the wrong path to see if the agent is registered
* Removed execute resources to disable auditd, replaced with `stop_command` on a service resource.

Replacement of #79.